### PR TITLE
changes to avoid reversing the bits in align_mantissa, avoid memory leaks, reduce memory usage

### DIFF
--- a/src/c/fldrf.c
+++ b/src/c/fldrf.c
@@ -31,7 +31,7 @@ fldrf_preprocess_t * fldrf_preprocess(double *a, int n) {
 
     struct array_s mantissas[n];
     for (int i = 0; i < n; i++) {
-        mantissas[i] = align_mantissa(ratios[i]);
+        mantissas[i] = ratios[i]->mantissa;
     }
 
     struct array_s m = binary_sum(mantissas, n);
@@ -65,7 +65,7 @@ fldrf_preprocess_t * fldrf_preprocess(double *a, int n) {
     }
 
     for (int i = 0; i < n; i++) {
-        free(mantissas[i].items);
+        double_s_free(ratios[i]);
     }
 
     fldrf_preprocess_t *x = malloc(sizeof(*x));
@@ -81,13 +81,22 @@ fldrf_preprocess_t * fldrf_preprocess(double *a, int n) {
 void normalize_double_s(struct double_s *d[], int n) {
     int max_exponent = d[0]->exponent;
     for (int i = 1; i < n; i++) {
-        max_exponent = fmax(max_exponent, d[i]->exponent);
+        if (d[i]->exponent > max_exponent)
+            max_exponent = d[i]->exponent;
     }
     for (int i = 0; i < n; i++) {
         int offset = max_exponent - d[i]->exponent;
         d[i]->offset += offset;
         d[i]->width += offset;
         d[i]->exponent = max_exponent;
+        if (offset != 0) {
+            int oldwidth = d[i]->width - offset;
+            struct array_s shifted = alloc_array_s(d[i]->width + d[i]->offset);
+            struct array_s *m = &d[i]->mantissa;
+            memmove(&shifted.items[offset], m->items, oldwidth*sizeof(*m->items));
+            array_s_free(d[i]->mantissa);
+            d[i]->mantissa = shifted;
+        }
     }
 }
 
@@ -126,31 +135,19 @@ struct double_s * as_integer_ratio(double x) {
 struct array_s decimal_to_binary(double x, int *width) {
     assert(x == floor(x));
 
-    struct array_s bits;
-    bits.length = DBL_MAX_WIDTH;
-    bits.items = calloc(bits.length, sizeof(*bits.items));
+    bit_t bits[DBL_MAX_WIDTH];
 
     int w = 0;
     while (0 < x) {
-        bits.items[w++] = fmod(x, 2);
+        bits[w++] = fmod(x, 2);
         x = floor(x/2);
     }
 
     *width = w;
-    return bits;
-}
-
-struct array_s align_mantissa(struct double_s *d) {
-    struct array_s mantissa;
-    mantissa.length = d->width + d->offset;
-    mantissa.items = calloc(mantissa.length, sizeof(*mantissa.items));
-
-    int start = d->width - 1;
-    for (int i = 0; i < d->width; i++) {
-        mantissa.items[start-i] = d->mantissa.items[i];
-    }
-
-    return mantissa;
+    struct array_s v = alloc_array_s(w);
+    memmove(v.items, bits, w*sizeof(*bits));
+    v.length = w;
+    return v;
 }
 
 struct array_s compute_reject_bits(struct array_s m, int *k) {
@@ -162,11 +159,10 @@ struct array_s compute_reject_bits(struct array_s m, int *k) {
         r.items = NULL;
     } else {
         *k = m.length;
-        struct array_s pow_2k;
-        pow_2k.length = *k + 1;
-        pow_2k.items = calloc(*k + 1, sizeof(*pow_2k.items));
+        struct array_s pow_2k = alloc_array_s(*k + 1);
         pow_2k.items[0] = 1;
         r = binary_sub(pow_2k, m);
+        array_s_free(pow_2k);
         assert(r.length <= *k);
     }
 
@@ -193,21 +189,20 @@ struct array_s binary_add(struct array_s a, struct array_s b) {
     int l = lb < la ? la : lb;
     int c = 0;
     int length = l+1;
-    int *y = calloc(length, sizeof(*y));
+    struct array_s y = alloc_array_s(length);
 
     for (int i = 1; i < l + 1; i++) {
         int ai = (0 <= la - i) ? a.items[la - i] : 0;
         int bi = (0 <= lb - i) ? b.items[lb - i] : 0;
-        y[l+1-i] = ((ai ^ bi) ^ c);
+        y.items[l+1-i] = ((ai ^ bi) ^ c);
         c = (ai & bi) | (ai & c) | (bi & c);
     }
     if (c == 1) {
-       y[0] = 1;
+       y.items[0] = 1;
     }
 
-    struct array_s x = {.length = length, .items = y};
-    remove_leading_zeros(&x);
-    return x;
+    remove_leading_zeros(&y);
+    return y;
 }
 
 struct array_s binary_sub(struct array_s a, struct array_s b){
@@ -216,21 +211,20 @@ struct array_s binary_sub(struct array_s a, struct array_s b){
     int l = lb < la ? la : lb;
     int c = 0;
     int length = l+1;
-    int *y = calloc(length, sizeof(*y));
+    struct array_s y = alloc_array_s(length);
 
     for (int i = 1; i < l + 1; i++) {
         int ai = (0 <= la - i) ? a.items[la - i] : 0;
         int bi = (0 <= lb - i) ? b.items[lb - i] : 0;
-        y[l+1-i] = ((ai ^ bi) ^ c);
+        y.items[l+1-i] = ((ai ^ bi) ^ c);
         c = c & (!(ai ^ bi)) | (!ai & bi);
     }
     if (c == 1) {
-       y[0] = 1;
+       y.items[0] = 1;
     }
 
-    struct array_s x = {.length = length, .items = y};
-    remove_leading_zeros(&x);
-    return x;
+    remove_leading_zeros(&y);
+    return y;
 }
 
 void remove_leading_zeros(struct array_s *a) {
@@ -288,6 +282,13 @@ int fldrf_sample(fldrf_preprocess_t *x) {
             c = c + 1;
         }
     }
+}
+
+struct array_s alloc_array_s(int length) {
+   struct array_s a;
+   a.length = length;
+   a.items = calloc(length, sizeof(*a.items));
+   return a;
 }
 
 void array_s_free(struct array_s x) {

--- a/src/c/fldrf.h
+++ b/src/c/fldrf.h
@@ -10,9 +10,11 @@
 #ifndef FLDRF_H
 #define FLDRF_H
 
+typedef unsigned char bit_t;
+
 struct array_s {
     int length;
-    int *items;
+    bit_t *items;
 };
 
 struct double_s {
@@ -34,6 +36,7 @@ typedef struct fldrf_s fldrf_preprocess_t;
 
 fldrf_preprocess_t * fldrf_preprocess(double *a, int n);
 
+struct array_s alloc_array_s(int length);
 void normalize_double_s(struct double_s *d[], int n);
 struct double_s * as_integer_ratio(double x);
 struct array_s decimal_to_binary(double x, int *width);

--- a/src/c/samplef.c
+++ b/src/c/samplef.c
@@ -23,7 +23,18 @@ double * load_array(FILE *fp, int length) {
     return a;
 }
 
-void * write_array(FILE *fp, int *x, int n) {
+void write_array(FILE *fp, int *x, int n) {
+    for (int j = 0; j < n; j++) {
+        if (j < n - 1) {
+            fprintf(fp, "%d ", x[j]);
+        } else {
+            fprintf(fp, "%d", x[j]);
+        }
+    }
+    fprintf(fp, "\n");
+}
+
+void write_bit_array(FILE *fp, bit_t *x, int n) {
     for (int j = 0; j < n; j++) {
         if (j < n - 1) {
             fprintf(fp, "%d ", x[j]);
@@ -41,8 +52,8 @@ void write_fldrf_s(char *fname, fldrf_preprocess_t *x) {
     fprintf(fp, "%d %d", x->n, x->k);
     fprintf(fp, "\n");
 
-    write_array(fp, x->m.items, x->m.length);
-    write_array(fp, x->r.items, x->r.length);
+    write_bit_array(fp, x->m.items, x->m.length);
+    write_bit_array(fp, x->r.items, x->r.length);
     write_array(fp, x->h, x->k);
 
     for (int row = 0; row < x->n + 1; row++){


### PR DESCRIPTION
I have done a Go implementation of this pretty algorithm, for both integer and floating-point weights. In the process I ended up making various changes to the C reference version for floating-point weights, prompted by things I noticed when working on the version of that in Go.
Those changes to that reference code form the subject of this pull request.

The existing code implements the rational representation in a straightforward way, similar to software floating-point.

Some minor points: the fmax for maximum exponent is going to and from double; ratios are not freed; pow2k is not freed; decimal_to_binary leaves the result with maximum length; using byte (unsigned char) instead of ints to store bits saves a little space.

The main change is as follows.

Looking at fldrf.c, in fldrf_preprocess, I see

    struct array_s mantissas[n];
    for (int i = 0; i < n; i++) {
        mantissas[i] = align_mantissa(ratios[i]);
    }

    struct array_s m = binary_sum(mantissas, n);

but align_mantissa has 

    int start = d->width - 1;
    for (int i = 0; i < d->width; i++) {
        mantissa.items[start-i] = d->mantissa.items[i];
    }

which surprised me, since it reverses the order of the bits in the mantissa, then all the reversed-bit mantissas are added together in preprocess.

I tried to think of justifications for it, but I suspect it's a mistake, and that the intention was to position the mantissa value in its original order at the correct offset inside the extended items value, so that the same positions are aligned across all mantissa values for the later addition.

It's tricky to get the position right in align_mantissa as it stood, because the width value it needs to position d->mantissa.items correctly in the new, larger mantissa items array has already been changed by normalize_double_s and, because decimal_to_binary leaves all values at full length
the width it needs can't be recovered from d->mantissa.length.

In the first fix, I had decimal_to_binary put the bits array into an array_s of the right length, and then align_mantissa could use that to position items correctly in the aligned copy, with the bits in the original order.

Later I decided that it would be clearer if normalize_double_s did that itself, which is the version in my branch. That way the width reflects the value actually stored in d[i]->mantissa.

I kept the change to decimal_to_binary, though, to use the minimal size (length==width).
As part of that, and changing `int* items' to `bit_t* items', I added an allocation function for struct array_s, which mirrors the free function.